### PR TITLE
chore: simplify ui-icon component

### DIFF
--- a/apps/platform/src/app/app/navbar/nav-button/nav-button.component.html
+++ b/apps/platform/src/app/app/navbar/nav-button/nav-button.component.html
@@ -19,12 +19,7 @@
     ease-in-out
   "
 >
-  <ui-icon
-    class="inline-block -mb-1"
-    *ngIf="icon"
-    [icon]="icon"
-    [iconSource]="iconSource"
-  ></ui-icon>
+  <ui-icon class="inline-block -mb-1" *ngIf="icon" [icon]="icon"></ui-icon>
   {{ routeName }}
 </a>
 
@@ -49,12 +44,7 @@
       ease-in-out
     "
   >
-    <ui-icon
-      class="inline-block -mb-1"
-      *ngIf="icon"
-      [icon]="icon"
-      [iconSource]="iconSource"
-    ></ui-icon>
+    <ui-icon class="inline-block -mb-1" *ngIf="icon" [icon]="icon"></ui-icon>
     {{ routeName }}
   </a>
 </ng-template>

--- a/apps/platform/src/app/app/navbar/navbar.component.html
+++ b/apps/platform/src/app/app/navbar/navbar.component.html
@@ -62,7 +62,6 @@
                 link="https://discord.gg/qZ8Zw2RgHq"
                 routeName="Discord"
                 target="_blank"
-                iconSource="beemstream"
                 [icon]="'discord'"
               ></nbp-nav-button>
               <nbp-nav-button
@@ -86,7 +85,6 @@
               <ng-template #loginButton>
                 <nbp-nav-button
                   icon="twitch"
-                  iconSource="beemstream"
                   linkType="href"
                   routeName="Sign In"
                   [link]="twitchOauthUrl"

--- a/apps/platform/src/app/app/navbar/navbar.component.html
+++ b/apps/platform/src/app/app/navbar/navbar.component.html
@@ -76,10 +76,10 @@
                 class="flex"
                 *ngIf="userDetails | async as userDetails$; else loginButton"
               >
-                <fa-icon class="text-xl" [icon]="faUserCircle"></fa-icon>
+                <ui-icon class="text-xl" [icon]="faUserCircle"></ui-icon>
                 <span class="self-center pl-2">{{ userDetails$?.login }}</span>
                 <button (click)="logout()">
-                  <fa-icon class="pl-2 text-xl" [icon]="faSignOutAlt"></fa-icon>
+                  <ui-icon class="pl-2 text-xl" [icon]="faSignOutAlt"></ui-icon>
                 </button>
               </div>
               <ng-template #loginButton>
@@ -98,7 +98,7 @@
         class="block p-5 text-white cursor-pointer md:block lg:hidden"
         (click)="toggleMobileNav()"
       >
-        <fa-icon class="text-xl" [icon]="icon"></fa-icon>
+        <ui-icon class="text-xl" [icon]="icon"></ui-icon>
       </div>
     </div>
     <div [class.hidden]="!isNavActive" class="pb-4 text-white lg:hidden">
@@ -125,7 +125,7 @@
             linkType="routerLink"
             linkName="Surprise Me!"
           >
-            <fa-icon class="pr-2" [icon]="faGift"></fa-icon>
+            <ui-icon class="pr-2" [icon]="faGift"></ui-icon>
           </ui-link>
         </li>
         <li class="p-3">
@@ -147,7 +147,7 @@
             target="_blank"
             linkName="Survey"
           >
-            <fa-icon class="pr-2" [icon]="faList"></fa-icon>
+            <ui-icon class="pr-2" [icon]="faList"></ui-icon>
           </ui-link>
         </li>
         <li class="p-3">
@@ -155,10 +155,10 @@
             class="flex"
             *ngIf="userDetails | async as userDetails$; else mobileLogin"
           >
-            <fa-icon class="text-xl" [icon]="faUserCircle"></fa-icon>
+            <ui-icon class="text-xl" [icon]="faUserCircle"></ui-icon>
             <span class="self-center pl-2">{{ userDetails$?.login }}</span>
             <button (click)="logout()">
-              <fa-icon class="pl-2 text-xl" [icon]="faSignOutAlt"></fa-icon>
+              <ui-icon class="pl-2 text-xl" [icon]="faSignOutAlt"></ui-icon>
             </button>
           </div>
           <ng-template #mobileLogin>

--- a/apps/platform/src/app/browse/browse.module.ts
+++ b/apps/platform/src/app/browse/browse.module.ts
@@ -9,9 +9,9 @@ import {
   StreamCardModule,
   EscapeHtmlPipe,
   ImgSizePipeModule,
+  IconModule,
 } from '@frontend-v2/shared-ui';
 import { StreamCategoryListComponent } from './stream-category-list/stream-category-list.component';
-import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { CategoryHeaderComponent } from './category-header/category-header.component';
 import { BrowseCategoryDetailComponent } from './browse-category-detail/browse-category-detail.component';
 import { FiltersModule } from '../shared/filter-stream-list/filters/filters.module';
@@ -30,7 +30,7 @@ import { StreamCategoryService } from '../services/stream-category.service';
     CommonModule,
     BrowseRoutingModule,
     StreamCardModule,
-    FontAwesomeModule,
+    IconModule,
     ButtonModule,
     LinkModule,
     FiltersModule,

--- a/apps/platform/src/app/browse/category-header/category-header.component.html
+++ b/apps/platform/src/app/browse/category-header/category-header.component.html
@@ -1,16 +1,16 @@
 <div class="grid grid-cols-2">
   <div class="mb-5">
     <ui-link class="font-semibold" [routerLink]="link" [linkName]="title"
-      ><fa-icon
+      ><ui-icon
         class="text-xl pr-2"
         *ngIf="titleIcon"
         [icon]="titleIcon"
-      ></fa-icon
+      ></ui-icon
     ></ui-link>
   </div>
   <div class="absolute right-10" *ngIf="showLink">
     <ui-button [routerLink]="link"
-      ><fa-icon [icon]="faArrowRight"></fa-icon
+      ><ui-icon [icon]="faArrowRight"></ui-icon
     ></ui-button>
   </div>
 </div>

--- a/apps/platform/src/app/shared/filter-stream-list/filters/code-icon/code-icon.component.html
+++ b/apps/platform/src/app/shared/filter-stream-list/filters/code-icon/code-icon.component.html
@@ -2,5 +2,4 @@
   class="pr-2"
   [attr.style]="icon !== 'uncategorized' ? 'padding-top: 2px' : null"
   [icon]="icon !== 'uncategorized' ? icon : faQuestion"
-  [iconSource]="icon === 'uncategorized' ? 'fa' : 'beemstream'"
 ></ui-icon>

--- a/apps/platform/src/app/shared/filter-stream-list/filters/dropdown-category-filter/dropdown-category-filter.component.html
+++ b/apps/platform/src/app/shared/filter-stream-list/filters/dropdown-category-filter/dropdown-category-filter.component.html
@@ -1,13 +1,13 @@
 <ng-template #template let-option>
   <div>
     <a>
-      <fa-icon [icon]="option.icon" class="pr-2"></fa-icon> {{ option.value }}
+      <ui-icon [icon]="option.icon" class="pr-2"></ui-icon> {{ option.value }}
     </a>
   </div>
 </ng-template>
 
 <ng-template #titleTemplate>
-  <fa-icon class="pr-2" [icon]="active.icon"></fa-icon
+  <ui-icon class="pr-2" [icon]="active.icon"></ui-icon
   ><span>{{ active.value }}</span>
 </ng-template>
 

--- a/apps/platform/src/app/shared/filter-stream-list/filters/dropdown-code-lang-select/dropdown-code-lang-select.component.html
+++ b/apps/platform/src/app/shared/filter-stream-list/filters/dropdown-code-lang-select/dropdown-code-lang-select.component.html
@@ -4,7 +4,7 @@
 </ng-template>
 
 <ng-template #titleTemplate>
-  <ui-icon class="pr-2" [icon]="faCode" iconSource="fa"></ui-icon>
+  <ui-icon class="pr-2" [icon]="faCode"></ui-icon>
   Programming Languages
 </ng-template>
 

--- a/apps/platform/src/app/shared/filter-stream-list/filters/dropdown-lang-select/dropdown-lang-select.component.html
+++ b/apps/platform/src/app/shared/filter-stream-list/filters/dropdown-lang-select/dropdown-lang-select.component.html
@@ -3,7 +3,7 @@
 </ng-template>
 
 <ng-template #titleTemplate>
-  <ui-icon class="pr-2" [icon]="faGlobe" iconSource="fa"></ui-icon>
+  <ui-icon class="pr-2" [icon]="faGlobe"></ui-icon>
   Languages
 </ng-template>
 

--- a/apps/platform/src/app/stream-detail/stream-detail.component.html
+++ b/apps/platform/src/app/stream-detail/stream-detail.component.html
@@ -16,11 +16,11 @@
       <div class="float-right pr-2">
         <div class="mr-1">
           {{ streamDetail.user_info.display_name }}
-          <fa-icon [icon]="faUser"></fa-icon>
+          <ui-icon [icon]="faUser"></ui-icon>
         </div>
         <div>
           {{ streamDetail.user_info.view_count }}
-          <fa-icon [icon]="faTv"></fa-icon>
+          <ui-icon [icon]="faTv"></ui-icon>
         </div>
       </div>
     </div>

--- a/apps/platform/src/app/stream-detail/stream-detail.module.ts
+++ b/apps/platform/src/app/stream-detail/stream-detail.module.ts
@@ -4,12 +4,11 @@ import { CommonModule } from '@angular/common';
 import { StreamDetailRoutingModule } from './stream-detail-routing.module';
 import { StreamDetailComponent } from './stream-detail.component';
 import { StreamViewComponent } from './stream-view/stream-view.component';
-import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { ImgSizePipe } from '@frontend-v2/shared-ui';
+import { IconModule, ImgSizePipe } from '@frontend-v2/shared-ui';
 
 @NgModule({
   declarations: [StreamDetailComponent, StreamViewComponent],
-  imports: [CommonModule, StreamDetailRoutingModule, FontAwesomeModule],
+  imports: [CommonModule, StreamDetailRoutingModule, IconModule],
   providers: [ImgSizePipe],
 })
 export class StreamDetailModule {}

--- a/libs/shared-ui/src/lib/icon/icon.component.html
+++ b/libs/shared-ui/src/lib/icon/icon.component.html
@@ -1,6 +1,6 @@
 <div
   #svgContainer
-  *ngIf="iconSource === 'beemstream'; else fa"
+  *ngIf="isBeemStreamSource; else fa"
   class="w-5 fill-current svg"
   [innerHTML]="svg"
 ></div>

--- a/libs/shared-ui/src/lib/icon/icon.component.ts
+++ b/libs/shared-ui/src/lib/icon/icon.component.ts
@@ -25,7 +25,7 @@ export class IconComponent implements OnInit, AfterViewInit {
 
   svg!: SafeHtml;
 
-  @ViewChild('svgContainer') svgContainerElem!: ElementRef;
+  @ViewChild('svgContainer') svgContainerElem!: ElementRef<HTMLDivElement>;
 
   constructor(
     private sanitzer: DomSanitizer,
@@ -34,8 +34,9 @@ export class IconComponent implements OnInit, AfterViewInit {
 
   ngAfterViewInit(): void {
     if (this.isBeemStreamSource) {
-      const svg = this.svgContainerElem.nativeElement.querySelector('svg');
-      svg.setAttribute('class', `fill-current ${this.iconClass}`);
+      this.svgContainerElem.nativeElement
+        .querySelector('svg')
+        ?.setAttribute('class', `fill-current ${this.iconClass}`);
     }
   }
 

--- a/libs/shared-ui/src/lib/icon/icon.component.ts
+++ b/libs/shared-ui/src/lib/icon/icon.component.ts
@@ -9,7 +9,7 @@ import {
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { IconService } from '../icon.service';
-import { Icon } from '../programming-language-icon';
+import { Icon, IconSet } from '../programming-language-icon';
 
 @Component({
   selector: 'ui-icon',
@@ -18,13 +18,14 @@ import { Icon } from '../programming-language-icon';
 })
 export class IconComponent implements OnInit, AfterViewInit {
   @Input() icon!: Icon | IconProp;
-  @Input() iconSource: 'fa' | 'beemstream' = 'beemstream';
   @Input() iconClass = '';
-  finishedRender = false;
+  get isBeemStreamSource() {
+    return IconSet.map((i) => i.name).includes(this.icon as Icon);
+  }
 
   svg!: SafeHtml;
 
-  @ViewChild('svgContainer') svgContainerElem?: ElementRef;
+  @ViewChild('svgContainer') svgContainerElem!: ElementRef;
 
   constructor(
     private sanitzer: DomSanitizer,
@@ -32,14 +33,14 @@ export class IconComponent implements OnInit, AfterViewInit {
   ) {}
 
   ngAfterViewInit(): void {
-    if (this.iconSource === 'beemstream' && !this.finishedRender) {
-      const svg = this.svgContainerElem?.nativeElement.querySelector('svg');
+    if (this.isBeemStreamSource) {
+      const svg = this.svgContainerElem.nativeElement.querySelector('svg');
       svg.setAttribute('class', `fill-current ${this.iconClass}`);
     }
   }
 
   ngOnInit(): void {
-    if (this.iconSource === 'beemstream') {
+    if (this.isBeemStreamSource) {
       this.svg = this.sanitzer.bypassSecurityTrustHtml(
         this.iconService.getIcon(this.icon as Icon)
       );

--- a/libs/shared-ui/src/lib/stream-card/stream-card.component.html
+++ b/libs/shared-ui/src/lib/stream-card/stream-card.component.html
@@ -43,7 +43,7 @@
           ></ui-icon>
         </a>
         <div class="inline-block">
-          <fa-icon [icon]="faUser"></fa-icon>
+          <ui-icon [icon]="faUser"></ui-icon>
           <ui-link
             class="px-1 inline-flex"
             linkType="href"
@@ -54,7 +54,7 @@
         </div>
       </span>
       <span class="text-right"
-        ><fa-icon [icon]="faEye"></fa-icon> {{ viewerNo }}</span
+        ><ui-icon [icon]="faEye"></ui-icon> {{ viewerNo }}</span
       >
     </div>
   </div>

--- a/libs/shared-ui/src/lib/stream-card/stream-card.module.ts
+++ b/libs/shared-ui/src/lib/stream-card/stream-card.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { StreamCardComponent } from './stream-card.component';
-import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { RouterModule } from '@angular/router';
 import { LinkModule } from '../link/link.module';
 import { StreamTagModule } from '../stream-tag/stream-tag.module';
@@ -12,7 +11,7 @@ import { IconModule } from '../icon/icon.module';
   declarations: [StreamCardComponent, StreamUrlPipe],
   imports: [
     CommonModule,
-    FontAwesomeModule,
+    IconModule,
     RouterModule,
     LinkModule,
     StreamTagModule,


### PR DESCRIPTION
This is a small refactor so that when using `ui-icon` component, you do not need to have an `iconSource` input. Instead the component should first try to find the internal icons and if not found, assume that its a font-awesome icon. These changes also update all usages of `fa-icon` to use `ui-icon`.

Before:
```html
<ui-icon [icon]="faCode" iconSource="fa"></ui-icon>
```

After:
```html
<ui-icon [icon]="faCode"></ui-icon>
```