### PR TITLE
chore: extract twitch embed to service

### DIFF
--- a/apps/platform/src/app/services/twitch-embed.service.ts
+++ b/apps/platform/src/app/services/twitch-embed.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class TwitchEmbedService {
+  createEmbed(element: HTMLElement, channel: string) {
+    new Twitch.Embed(element, {
+      width: '100%',
+      height: '100%',
+      channel: channel,
+      theme: 'dark',
+    });
+  }
+}

--- a/apps/platform/src/app/stream-detail/stream-view/stream-view.component.ts
+++ b/apps/platform/src/app/stream-detail/stream-view/stream-view.component.ts
@@ -2,28 +2,28 @@ import { ViewChild } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import { AfterViewInit, Component, Input } from '@angular/core';
 import { faTv } from '@fortawesome/free-solid-svg-icons';
+import { TwitchEmbedService } from '../../services/twitch-embed.service';
 
 @Component({
   selector: 'nbp-stream-view',
   templateUrl: './stream-view.component.html',
   styleUrls: ['./stream-view.component.css'],
+  providers: [TwitchEmbedService],
 })
 export class StreamViewComponent implements AfterViewInit {
-  @Input() channel?: string;
-  @Input() channelImg?: string;
+  @Input() channel!: string;
+  @Input() channelImg!: string;
 
   faTv = faTv;
 
-  @ViewChild('twitchEmbed') twitchEmbedElem?: ElementRef;
+  @ViewChild('twitchEmbed') twitchEmbedElem!: ElementRef;
+
+  constructor(private twitchEmbedService: TwitchEmbedService) {}
 
   ngAfterViewInit(): void {
-    if (this.channel) {
-      new Twitch.Embed(this.twitchEmbedElem?.nativeElement, {
-        width: '100%',
-        height: '100%',
-        channel: this.channel,
-        theme: 'dark',
-      });
-    }
+    this.twitchEmbedService.createEmbed(
+      this.twitchEmbedElem.nativeElement,
+      this.channel
+    );
   }
 }


### PR DESCRIPTION
In order to add tests, its easier to have external dependencies/libraries to be a service. This service can then be very easily mocked within the angular test harness. stream-view component inputs also updated to be required rather than `string | undefined`