### PR TITLE
fix: account for oauth2 for query param filters

### DIFF
--- a/apps/platform/src/app/services/filter-query-params.service.ts
+++ b/apps/platform/src/app/services/filter-query-params.service.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import {
   BehaviorSubject,
   combineLatest,
+  EMPTY,
   map,
   Subscription,
   switchMap,
@@ -116,6 +117,8 @@ export class FilterQueryParamsService implements OnDestroy {
     this.subscription = this.activatedRoute.queryParams
       .pipe(
         switchMap((queryParams) => {
+          if (queryParams.code) return EMPTY;
+
           return Object.keys(queryParams).length > 0
             ? filterByQueryParams
             : trackFilters;


### PR DESCRIPTION
As a consequence of using router navigation having `queryParamsHandling: 'merge'` Oauth2 redirects would result in filters being appended to query params handling and overwriting url history and finishing the oauth2. We need to account for oauth2 flow first before we decide to handle filters